### PR TITLE
Fix ActiveSupport::Deprecation.warn deprecation

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -380,7 +380,7 @@ module Apipie
 
     # @deprecated Use {#get_resource_id} instead
     def get_resource_name(klass)
-      ActiveSupport::Deprecation.new.warn(
+      ActiveSupport::Deprecation.new('2.0', 'apipie-rails').warn(
         <<~HEREDOC
           Apipie::Application.get_resource_name is deprecated.
           Use `Apipie::Application.get_resource_id instead.

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -380,7 +380,7 @@ module Apipie
 
     # @deprecated Use {#get_resource_id} instead
     def get_resource_name(klass)
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport::Deprecation.new.warn(
         <<~HEREDOC
           Apipie::Application.get_resource_name is deprecated.
           Use `Apipie::Application.get_resource_id instead.

--- a/lib/apipie/generator/swagger/config.rb
+++ b/lib/apipie/generator/swagger/config.rb
@@ -17,7 +17,7 @@ module Apipie
         CONFIG_ATTRIBUTES.each do |attribute|
           old_setter_method = "swagger_#{attribute}="
           define_method(old_setter_method) do |value|
-            ActiveSupport::Deprecation.warn(
+            ActiveSupport::Deprecation.new.warn(
               <<~HEREDOC
                 config.#{old_setter_method}#{value} is deprecated.
                 config.generator.swagger.#{attribute} instead.
@@ -29,7 +29,7 @@ module Apipie
 
           old_setter_method = "swagger_#{attribute}"
           define_method(old_setter_method) do
-            ActiveSupport::Deprecation.warn(
+            ActiveSupport::Deprecation.new.warn(
               <<~HEREDOC
                 config.#{old_setter_method} is deprecated.
                 Use config.generator.swagger.#{attribute} instead.

--- a/lib/apipie/generator/swagger/config.rb
+++ b/lib/apipie/generator/swagger/config.rb
@@ -17,7 +17,7 @@ module Apipie
         CONFIG_ATTRIBUTES.each do |attribute|
           old_setter_method = "swagger_#{attribute}="
           define_method(old_setter_method) do |value|
-            ActiveSupport::Deprecation.new.warn(
+            ActiveSupport::Deprecation.new('2.0', 'apipie-rails').warn(
               <<~HEREDOC
                 config.#{old_setter_method}#{value} is deprecated.
                 config.generator.swagger.#{attribute} instead.
@@ -29,7 +29,7 @@ module Apipie
 
           old_setter_method = "swagger_#{attribute}"
           define_method(old_setter_method) do
-            ActiveSupport::Deprecation.new.warn(
+            ActiveSupport::Deprecation.new('2.0', 'apipie-rails').warn(
               <<~HEREDOC
                 config.#{old_setter_method} is deprecated.
                 Use config.generator.swagger.#{attribute} instead.


### PR DESCRIPTION
Fix deprecation method `ActiveSupport::Deprecation.warn`. Replaced with `ActiveSupport::Deprecation.new.warn` 